### PR TITLE
Add explicitly elasticsearch gateway setting when lanch test cluster, due to be set…

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -5,3 +5,4 @@ development:
 test:
   host: localhost:9250
   log: true
+  # gateway: local

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -3,7 +3,7 @@ yaml   = ERB.new(erb).result
 config = YAML.load(yaml)
 
 if (option = config[Rails.env])
-  Elasticsearch::Model.client = Elasticsearch::Client.new(ActiveSupport::HashWithIndifferentAccess.new(option))
+  Elasticsearch::Persistence.client = Elasticsearch::Client.new(ActiveSupport::HashWithIndifferentAccess.new(option))
 else
   warn 'No Elasticsearch configuration was found. Using default client.'
 end

--- a/spec/support/elacticsearch.rb
+++ b/spec/support/elacticsearch.rb
@@ -1,12 +1,17 @@
 require 'elasticsearch/extensions/test/cluster'
+#-------------------------------
+# ex) lanched elasticsearch
+#
+# elasticsearch -D es.foreground=yes -D es.cluster.name=elasticsearch-test-apple-no-macbook-pro.local -D es.node.name=node-1 -D es.http.port=9250 -D es.path.data=/tmp/elasticsearch_test -D es.path.work=/tmp -D es.path.logs=/tmp/log/elasticsearch -D es.cluster.routing.allocation.disk.threshold_enabled=false -D es.network.host=localhost -D es.script.inline=true -D es.script.stored=true -D es.node.attr.testattr=test -D es.path.repo=/tmp -D es.repositories.url.allowed_urls=http://snapshot.test* -D es.logger.level=DEBUG -D es.gateway=local
+# -----------------------------
 
 RSpec.configure do |config|
   config.before(:all, :elasticsearch) do
     WebMock.disable_net_connect!(allow_localhost: true)
-    Elasticsearch::Extensions::Test::Cluster.start port: 9250 unless Elasticsearch::Extensions::Test::Cluster.running?(on: 9250)
+    Elasticsearch::Extensions::Test::Cluster.start port: 9250, network_host: 'localhost', es_params: '-D es.gateway=local' unless Elasticsearch::Extensions::Test::Cluster.running?(on: 9250)
   end
 
   config.after(:all, :elasticsearch) do
-    Elasticsearch::Extensions::Test::Cluster.stop port: 9250 if Elasticsearch::Extensions::Test::Cluster.running?(on: 9250)
+    Elasticsearch::Extensions::Test::Cluster.stop port: 9250, network_host: 'localhost', es_params: '-D es.gateway=local' if Elasticsearch::Extensions::Test::Cluster.running?(on: 9250)
   end
 end


### PR DESCRIPTION
elasticsearch test cluster lancher not working...

``` rspec
Exception in thread "main" java.lang.IllegalArgumentException: Unknown [gateway] type [none]
    at org.elasticsearch.common.util.ExtensionPoint$SelectedType.bindType(ExtensionPoint.java:146)
    at org.elasticsearch.gateway.GatewayModule.configure(GatewayModule.java:53)
    at <<<guice>>>
    at org.elasticsearch.node.Node.<init>(Node.java:213)
    at org.elasticsearch.node.Node.<init>(Node.java:140)
    at org.elasticsearch.node.NodeBuilder.build(NodeBuilder.java:143)
    at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:178)
    at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:270)
    at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:35)
Refer to the log for complete error details.
:
Failure/Error: Elasticsearch::Extensions::Test::Cluster.start port: 9250, nodes: 1 unless Elasticsearch::Extensions::Test::Cluster.running?(on: 9250)
```
## my enviroment

```
kieaiaarh@ ~ $ curl localhost:9200
{
  "name" : "Sluggo",
  "cluster_name" : "elasticsearch_kieaiaarh",
  "version" : {
    "number" : "2.3.4",
    "build_hash" : "e455fd0c13dceca8dbbdbb1665d068ae55dabe3f",
    "build_timestamp" : "2016-06-30T11:24:31Z",
    "build_snapshot" : false,
    "lucene_version" : "5.5.0"
  },
  "tagline" : "You Know, for Search"
}
```

``` code:ruby
# elasticsearch↲
gem 'elasticsearch-persistence', git: 'git://github.com/elasticsearch/elasticsearch-rails.git'↲
gem 'elasticsearch-rails', git: 'git://github.com/elasticsearch/elasticsearch-rails.git'↲
gem 'elasticsearch-model', git: 'git://github.com/elasticsearch/elasticsearch-rails.git'↲
gem 'elasticsearch-extensions', git: 'git://github.com/elasticsearch/elasticsearch-ruby.git'↲
gem 'elasticsearch-dsl', git: 'git://github.com/elasticsearch/elasticsearch-ruby.git'↲
```
